### PR TITLE
Add default language

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://demsh.in" # the base hostname & protocol for your site
 # twitter_username: demshin
 github_username: demshin
+lang: ru
 
 # Build settings
 markdown: kramdown

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.lang | default: 'ru' }}">
 
 {% include head.html %}
 


### PR DESCRIPTION
## Summary
- set language configuration in `_config.yml`
- specify `lang` attribute in the default layout

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6843274f71c88321802c9a854c0eebbe