### PR TITLE
Fix duplicate .idea ignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 _site
 .sass-cache
 .jekyll-metadata
-/.idea/
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
- remove duplicate `.idea/` entry from `.gitignore`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432e107cc48321b9d5387b4342f201