### PR TITLE
Fix family post slug and redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,5 @@ paginate_path: "page:num"
 future: false
 
 theme: jekyll-theme-minimal
+plugins:
+  - jekyll-redirect-from

--- a/_posts/2019-06-05-how-to-work-with-family-remotely.md
+++ b/_posts/2019-06-05-how-to-work-with-family-remotely.md
@@ -3,6 +3,8 @@ layout: post
 title:  "Как работать в путешествии с семьей"
 date:   2019-06-12 14:22:00 +0500
 categories: working travels family
+redirect_from:
+  - /working/travels/family/2019/06/12/how-to-work-with-famaly-remotely.html
 ---
 
 В [telegram-чате](https://t.me/joinchat/AAAAAAo-Vju7cjFSfjZeeg) [otus.ru](https://otus.ru) меня попросили написать, как путешествовать с детьми и при этом работать удаленно. Ниже я попытаюсь это сделать.


### PR DESCRIPTION
## Summary
- rename post file to fix "family" slug
- configure `jekyll-redirect-from`
- add redirect from old URL to new one

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68432fed8980832189ebe26e6835290c