### PR TITLE
Add configurable GA key

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ My tech blog based on [Jekyll](https://jekyllrb.com) and available [here](https:
 
 ## Analytics
 
-This site uses Google Analytics 4 via `gtag.js`. Update `_includes/analytics.html` with your measurement ID.
+This site uses Google Analytics 4 via `gtag.js`. Set your measurement ID in `_config.yml` under `google_analytics_id`.

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ url: "https://demsh.in" # the base hostname & protocol for your site
 # twitter_username: demshin
 github_username: demshin
 lang: ru
+google_analytics_id: G-XKK8ZMW7D2
 
 # Build settings
 markdown: kramdown

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,10 +1,10 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-XKK8ZMW7D2"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_id }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-XKK8ZMW7D2');
+  gtag('config', '{{ site.google_analytics_id }}');
 </script>
 


### PR DESCRIPTION
## Summary
- add `google_analytics_id` setting
- use that variable in the analytics include
- document analytics setup in README
- set GA ID to `G-XKK8ZMW7D2`

## Testing
- `bundle install` *(failed: bundler command not found/installation incomplete)*
- `bundle exec jekyll build` *(failed: jekyll not installed)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6843301555908321b0ac28d8168bf97b