### PR TITLE
Add Jekyll pagination

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,5 @@ paginate_path: "page:num"
 future: false
 
 theme: jekyll-theme-minimal
+plugins:
+  - jekyll-paginate

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
   <h1 class="page-heading">Posts</h1>
 
   <ul class="post-list">
-    {% for post in site.posts %}
+    {% for post in paginator.posts %}
       <li>
         <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
 
@@ -18,6 +18,22 @@ layout: default
       </li>
     {% endfor %}
   </ul>
+
+  <div class="pagination">
+    {% if paginator.previous_page %}
+      <a class="previous" href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Previous</a>
+    {% else %}
+      <span class="previous">Previous</span>
+    {% endif %}
+
+    <span class="page-number">Page {{ paginator.page }} of {{ paginator.total_pages }}</span>
+
+    {% if paginator.next_page %}
+      <a class="next" href="{{ paginator.next_page_path | prepend: site.baseurl }}">Next</a>
+    {% else %}
+      <span class="next">Next</span>
+    {% endif %}
+  </div>
 
   <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
 


### PR DESCRIPTION
## Summary
- enable jekyll-paginate plugin
- list `paginator.posts` on the homepage
- add prev/next pagination links

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6843301deb288321ba2f495dfc095f05