### PR TITLE
Fix nav shows 404 link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
 
       <div class="trigger">
         {% for my_page in site.pages %}
-          {% if my_page.title %}
+          {% if my_page.title and my_page.url != '/404.html' %}
           <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
## Summary
- filter out `/404.html` from navigation menu

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_684334f060608321955588f7b4fafa36